### PR TITLE
Use more conventional Go code.

### DIFF
--- a/prime_growing_memory.go
+++ b/prime_growing_memory.go
@@ -1,24 +1,28 @@
 package main
 
-import "fmt"
-
 func main() {
+	const N = 20000000
 
-  var array_primes []int;
+	primes := make([]int, 0, N)
 
-  for i := 2; i < 20000000; i++ {
-    is_prime := true;
-    for j := 0; j < len(array_primes) && array_primes[j] * array_primes[j] <= i; j++ {
-      if i % array_primes[j] == 0 {
-        is_prime = false;
-        break;
-      }
-    }
-    if is_prime {
-      array_primes = append(array_primes, i);
-    }
-  }
-  fmt.Println(len(array_primes));
+	for num := 2; num < N; num++ {
+		isPrime := true
+		for _, prime := range primes {
+			if prime*prime > num {
+				break
+			}
+			if num%prime == 0 {
+				isPrime = false
+				break
+			}
+		}
+
+		if isPrime {
+			primes = append(primes, num)
+		}
+	}
+
+	println(len(primes))
 }
 
 //Compiled: go build -ldflags="-s -w"

--- a/prime_simple.go
+++ b/prime_simple.go
@@ -1,24 +1,25 @@
 package main
 
-import "fmt"
-
 func main() {
-  count := 0;
-  for i := 2; i < 20000000; i++ {
-    if is_prime(i) {
-      count += 1;
-    }
-  }
-  fmt.Println(count);
+	const N = 20000000
+
+	count := 0
+	for i := 2; i < N; i++ {
+		if isPrime(i) {
+			count += 1
+		}
+	}
+
+	println(count)
 }
 
-func is_prime(value int) bool {
-    for i := 2; i * i <= value; i++ {
-        if value % i == 0 {
-            return false
-        }
-    }
-    return true
+func isPrime(value int) bool {
+	for i := 2; i*i <= value; i++ {
+		if value%i == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 //Compiled: go build -ldflags="-s -w"

--- a/prime_slice_memory.go
+++ b/prime_slice_memory.go
@@ -1,28 +1,30 @@
 package main
 
-import "fmt"
-
 func main() {
+	const N = 20000000
 
-  var array_primes [20000000] int;
-  var slice_primes []int = array_primes[:0];
+	var primes [N]int
+	var head int
 
-  for i := 2; i < 20000000; i++ {
-    is_prime := true;
-    for j := 0; j < len(slice_primes) && slice_primes[j] * slice_primes[j] <= i; j++ {
-      if i % slice_primes[j] == 0 {
-        is_prime = false;
-        break;
-      }
-    }
-    if is_prime {
-      slice_length := len(slice_primes);
-      slice_primes = slice_primes[:slice_length + 1];  //Extend slice by 1.
-      slice_primes[slice_length] = i; //Set value
-    }
-  }
-  fmt.Println(len(slice_primes));
+	for num := 2; num < N; num++ {
+		isPrime := true
+		for _, prime := range primes[:head] {
+			if prime*prime > num {
+				break
+			}
+			if num%prime == 0 {
+				isPrime = false
+				break
+			}
+		}
 
+		if isPrime {
+			primes[head] = num
+			head++
+		}
+	}
+
+	println(head)
 }
 
 //Compiled: go build -ldflags="-s -w"


### PR DESCRIPTION
Nice write up.

I changed the code to look more like usual Go code.

The performance characteristics didn't change or at least I didn't notice. Except the `prime_growing_memory.go`, which improved from `9.29s` to `8.15s`, however that doesn't seem to line up with your measurements; not sure what's going on here.

By not importing `fmt` you can avoid depending on unicode tables, so the executable shrinks by a few hundred KB.